### PR TITLE
Add repository.yaml

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,2 @@
+name: Addon-Radrr
+url: https://github.com/lbouriez/addon-radarr


### PR DESCRIPTION
Add repository.yaml to allow adding the addon repository directly from Home Assistant addon store
